### PR TITLE
[Refactor] VStack - HStack을 Layout, Style 분리

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ import Providers from "@/components/providers";
 
 import "@/globals.css";
 
-// 웹 페이지의 기본 메타데이터이다.
 export const metadata: Metadata = {
   title: {
     default: siteConfig.name,
@@ -24,7 +23,6 @@ export const viewport: Viewport = {
   ],
 };
 
-// Header, Main, Footer 컴포넌트가 독립적으로 구성된다.
 export default function RootLayout({
   header,
   children,

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,20 +1,24 @@
 import Link from "next/link";
+import { HStack, VStack } from "@/components/stactk";
+
+function StyledText({ children }: { children: React.ReactNode }) {
+  return <span className="text-headline-large">{children}</span>;
+}
 
 export default function Footer() {
   return (
-    <footer className="flex items-center justify-between self-stretch bg-light-surfaceDim px-[10%] py-12 dark:bg-dark-surfaceDim">
-      <div className="flex flex-col gap-2">
-        <span className="text-headline-large">Team Thlee</span>
-        <span>Software Maestro 15th - 2024</span>
-      </div>
-      <div className="flex flex-col items-end gap-2">
-        <Link className="" href="https://github.com/SWM-Thlee">
-          Github
-        </Link>
-        <Link className="" href="mailto:cutehammond772@gmail.com">
-          Contact Us
-        </Link>
-      </div>
+    <footer className="self-stretch bg-light-surfaceDim px-[10%] py-12 dark:bg-dark-surfaceDim">
+      <HStack className="items-center justify-between self-stretch">
+        <VStack className="gap-2">
+          {/* StyledText를 적절한 네이밍의 Component로 규격화해서 관리할 수 있겠죠? 예를 들면, Body2 같은 네이밍으로요 */}
+          <StyledText>Team Thlee</StyledText>
+          <span>Software Maestro 15th - 2024</span>
+        </VStack>
+        <VStack className="items-end gap-2">
+          <Link href="https://github.com/SWM-Thlee">Github</Link>
+          <Link href="mailto:cutehammond772@gmail.com">Contact Us</Link>
+        </VStack>
+      </HStack>
     </footer>
   );
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Navigation as UiNavigation } from "@/ui/navigation";
+import { HStack } from "@/components/stactk";
 import { modules } from "./main-navigation-modules";
 
 export default function Navigation() {
   return (
-    <div className="justify-self-center">
+    <HStack className="justify-self-center">
       <UiNavigation _color="primary" modules={modules} />
-    </div>
+    </HStack>
   );
 }

--- a/components/stactk.tsx
+++ b/components/stactk.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from "react";
+
+interface StackProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function VStack({ children, className = "", ...props }: StackProps) {
+  return (
+    <div className={`flex flex-col ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function HStack({ children, className = "", ...props }: StackProps) {
+  return (
+    <div className={`flex flex-row ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export { VStack, HStack };

--- a/features/search/components/navigation/content/history.tsx
+++ b/features/search/components/navigation/content/history.tsx
@@ -7,6 +7,15 @@ import Button from "@/ui/button";
 
 import useIsClient from "@/hooks/use-is-client";
 import useSearchHistory from "@/features/search/hooks/use-search-history";
+import { HStack, VStack } from "@/components/stactk";
+
+function StyledTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-title-medium text-light-onSurface dark:text-dark-onSurface">
+      {children}
+    </div>
+  );
+}
 
 export default function SearchNavigationHistory() {
   // 검색 기록은 (현재는) 클라이언트에 종속되므로 이를 고려합니다.
@@ -14,48 +23,53 @@ export default function SearchNavigationHistory() {
   const history = useSearchHistory();
 
   return (
-    <div className="flex flex-col justify-between gap-4 overflow-y-auto rounded-[16px] border-[1px] border-light-outlineVariant p-4 scrollbar dark:border-dark-outlineVariant">
-      <div className="flex items-center gap-4 text-title-medium text-light-onSurface dark:text-dark-onSurface">
-        <HistoryIcon /> Recent Search History
-      </div>
-      {isClient && (
-        <Accordion.Root type="single" ui_variant="list" collapsible>
-          {history.map(({ id, query }) => (
-            <Accordion.ListItem
-              value={id}
-              key={id}
-              ui_size="large"
-              ui_trigger={query}
-              ui_content={
-                <div className="flex justify-between gap-2">
-                  <Popover
-                    trigger={
-                      <Button _color="tertiary" _size="small">
-                        Filters
-                      </Button>
-                    }
-                  >
-                    Hello
-                  </Popover>
-                  <div className="flex gap-2">
-                    <Button
-                      _color="secondary"
-                      _variant="bordered"
-                      _size="small"
+    <div className="overflow-y-auto rounded-[16px] border-[1px] border-light-outlineVariant p-4 scrollbar dark:border-dark-outlineVariant">
+      {/* Layout과 Style을 분리했는데, 스타일과 레이아웃이 분리되면 유지보수가 쉽고, 가독성이 향상됩니다. */}
+      <VStack className="justify-between gap-4">
+        <HStack className="items-center gap-4">
+          <HistoryIcon />
+          {/* StyledTitle을 공통 텍스트 컴포넌트로 추출하는 방법도 있겠죠? 예를 들어, SubTitle, Title, Caption 등으로 일관된 컴포넌트로 관리하는것이 가능합니다 */}
+          <StyledTitle>Recent Search History</StyledTitle>
+        </HStack>
+        {isClient && (
+          <Accordion.Root type="single" ui_variant="list" collapsible>
+            {history.map(({ id, query }) => (
+              <Accordion.ListItem
+                value={id}
+                key={id}
+                ui_size="large"
+                ui_trigger={query}
+                ui_content={
+                  <HStack className="justify-between gap-2">
+                    <Popover
+                      trigger={
+                        <Button _color="tertiary" _size="small">
+                          Filters
+                        </Button>
+                      }
                     >
-                      Edit
-                    </Button>
-                    <Button _color="error" _variant="bordered" _size="small">
-                      Delete
-                    </Button>
-                    <Button _size="small">Search</Button>
-                  </div>
-                </div>
-              }
-            />
-          ))}
-        </Accordion.Root>
-      )}
+                      Hello
+                    </Popover>
+                    <HStack className="gap-2">
+                      <Button
+                        _color="secondary"
+                        _variant="bordered"
+                        _size="small"
+                      >
+                        Edit
+                      </Button>
+                      <Button _color="error" _variant="bordered" _size="small">
+                        Delete
+                      </Button>
+                      <Button _size="small">Search</Button>
+                    </HStack>
+                  </HStack>
+                }
+              />
+            ))}
+          </Accordion.Root>
+        )}
+      </VStack>
     </div>
   );
 }


### PR DESCRIPTION
### 무엇을 한 PR 인가요?
- Tailwind CSS 레이아웃 구조 개선을 위해 VStack과 HStack 컴포넌트를 간단한 방법으로 도입했습니다.
  - 기존의 수직 및 수평 배치 Layout을 더 명확하고 재사용 가능하도록 리팩토링을 진행했습니다.
- 스타일과 레이아웃을 분리하여 유지보수성과 가독성을 향상시키는 작업을 진행했습니다.
- Footer와 기타 여러 컴포넌트에서 레이아웃 관련 코드를 VStack, HStack으로 리팩토링하여 사용 방법을 명시했습니다.
- 그 외 불필요한 주석[코드로 설명이 되는 부분들]을 제거했습니다.

### 리뷰어가 중점적으로 확인해 주었으면 하는 부분이 무엇인가요?
- 레이아웃과 스타일의 분리가 코드 가독성과 유지보수에 긍정적인 영향을 미치는지, 개선할 부분이 있는지 확인 부탁드립니다.
- 작업한 컴포넌트들이 의도한 스타일과 레이아웃을 유지하고 있는지 크로스체크 부탁드립니다.

### 체크 포인트
- VStack과 HStack 컴포넌트의 재사용성 및 유연성을 가지려면 지금 구조에서 어떻게 변경하고 확장해볼 수 있을까요?
- Text 에 적용되고 있는 다양한 Style들을 어떻게 관리해볼 수 있을까요?
- 주석으로 적절한 질문과 생각할 포인트를 남겨놓았습니다. 참고해주세요.